### PR TITLE
Pin onnxruntime-silicon version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## [Unreleased]
+- Pinned `onnxruntime-silicon` to version **1.13.1** for Apple Silicon compatibility.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ torch==2.5.1+cu118; sys_platform != 'darwin'
 torch==2.5.1; sys_platform == 'darwin'
 torchvision==0.20.1; sys_platform != 'darwin'
 torchvision==0.20.1; sys_platform == 'darwin'
-onnxruntime-silicon==1.16.3; sys_platform == 'darwin' and platform_machine == 'arm64'
+onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.17; sys_platform != 'darwin'
 tensorflow; sys_platform != 'darwin'
 opennsfw2==0.10.2


### PR DESCRIPTION
## Summary
- pin Apple Silicon onnxruntime version
- note the version in `CHANGELOG.md`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684910c70cd083328201e6422298b82b