### PR TITLE
Add scikit-learn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Place these files in the "**models**" folder.
 **4. Install Dependencies**
 
 We highly recommend using a `venv` to avoid issues.
+The `requirements.txt` file now includes `scikit-learn==1.4.2`.
 
 
 For Windows:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ onnxruntime-gpu==1.17; sys_platform != 'darwin'
 tensorflow; sys_platform != 'darwin'
 opennsfw2==0.10.2
 protobuf==4.23.2
+
+scikit-learn==1.4.2


### PR DESCRIPTION
## Summary
- add scikit-learn to requirements.txt
- document new dependency in manual installation instructions

## Testing
- `python -m venv venvtest && source venvtest/bin/activate && pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684910c829688332bacfb928356ed9a3