### PR TITLE
Fix imwrite_unicode and add test

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,4 +1,4 @@
-import os 
+import os
 import cv2
 import numpy as np
 
@@ -8,11 +8,12 @@ def imread_unicode(path, flags=cv2.IMREAD_COLOR):
 
 # Utility function to support unicode characters in file paths for writing
 def imwrite_unicode(path, img, params=None):
+    """Write ``img`` to ``path`` even if the path contains non ASCII characters."""
     root, ext = os.path.splitext(path)
     if not ext:
         ext = ".png"
-        result, encoded_img = cv2.imencode(ext, img, params if params else [])
-        result, encoded_img = cv2.imencode(f".{ext}", img, params if params is not None else [])
+        path = path + ext
+    result, encoded_img = cv2.imencode(ext, img, params if params is not None else [])
+    if result:
         encoded_img.tofile(path)
-        return True
-    return False
+    return bool(result)

--- a/tests/test_imwrite_unicode.py
+++ b/tests/test_imwrite_unicode.py
@@ -1,0 +1,11 @@
+import numpy as np
+from modules import imwrite_unicode, imread_unicode
+
+def test_imwrite_unicode(tmp_path):
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    path = tmp_path / 'テスト画像'
+    assert imwrite_unicode(str(path), img)
+    saved = path.with_suffix('.png')
+    assert saved.exists()
+    loaded = imread_unicode(str(saved))
+    assert loaded.shape == img.shape


### PR DESCRIPTION
## Summary
- fix unicode image saving helper
- add regression test for unicode paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684910c956b48332b92d37b428ae8f2a