### PR TITLE
Update macOS memory limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,10 @@ python3.10 run.py --execution-provider coreml
   brew cleanup
   ```
 
+- The `--max-memory` option limits RAM usage in gigabytes. macOS caps this value
+  by its current hard limit, so the program automatically lowers the request if
+  needed.
+
 **CoreML Execution Provider (Apple Legacy)**
 
 1. Install dependencies:


### PR DESCRIPTION
## Summary
- cap memory usage on macOS using gigabytes
- handle RLIMIT_DATA hard limit on macOS
- document macOS memory cap in README

## Testing
- `python -m py_compile modules/core.py`
- `python -m py_compile modules/globals.py`


------
https://chatgpt.com/codex/tasks/task_e_684910cbd1288332924f8a13a6d2de27